### PR TITLE
Implemented function templates to allow JS callbacks into rust code with object templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.5.8"
 [dependencies]
 error-chain = "0.5.0"
 lazy_static = "0.2.1"
-v8-sys = "0.10.0"
+v8-sys = { version = "0.10.0", path = "v8-sys" }
 
 [features]
 shared = ["v8-sys/shared"]

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -47,10 +47,10 @@ impl Isolate {
         }
     }
 
-    pub fn current_context(&self) -> context::Context {
+    pub fn current_context(&self) -> Option<context::Context> {
         unsafe { 
-            let raw = v8::Isolate_GetCurrentContext(self.as_raw());
-            context::Context::from_raw(self, raw)
+            let raw = v8::Isolate_GetCurrentContext(self.as_raw()).as_mut();
+            raw.map(|r| context::Context::from_raw(self, r))
         }
     }
 }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -2,6 +2,7 @@ use std::mem;
 use std::sync;
 use v8_sys as v8;
 use allocator;
+use context;
 use platform;
 
 static INITIALIZE: sync::Once = sync::ONCE_INIT;
@@ -43,6 +44,13 @@ impl Isolate {
         match self.0 {
             IsolateHolder::Owned(p, _) => p,
             IsolateHolder::Borrowed(p) => p,
+        }
+    }
+
+    pub fn current_context(&self) -> context::Context {
+        unsafe { 
+            let raw = v8::Isolate_GetCurrentContext(self.as_raw());
+            context::Context::from_raw(self, raw)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
 
     fn test_function<'a>(info: &'a value::FunctionCallbackInfo) -> value::Value<'a> {
         let i = info.isolate;
-        let c = i.current_context();
+        let c = i.current_context().unwrap();
 
         assert_eq!(2, info.length);
         let ref a = info.args[0];
@@ -586,7 +586,8 @@ mod tests {
     fn run_defined_static_function() {
         let i = Isolate::new();
         let c = Context::new(&i);
-        let f = value::Function::new(&i, &c, 2, &test_function);
+        let fr = &test_function;
+        let f = value::Function::new(&i, &c, 2, fr);
 
         let k = value::String::from_str(&i, "f");
         c.global().set(&c, &k, &f);
@@ -604,7 +605,8 @@ mod tests {
     fn run_defined_function_template_instance() {
         let i = Isolate::new();
         let c = Context::new(&i);
-        let ft = template::FunctionTemplate::new(&i, &c, &test_function);
+        let fr = &test_function;
+        let ft = template::FunctionTemplate::new(&i, &c, fr);
         let f = ft.get_function(&c);
 
         let k = value::String::from_str(&i, "f");
@@ -644,7 +646,8 @@ mod tests {
         let i = Isolate::new();
         let c = Context::new(&i);
         let ot = template::ObjectTemplate::new(&i);
-        let ft = template::FunctionTemplate::new(&i, &c, &test_function);
+        let fr = &test_function;
+        let ft = template::FunctionTemplate::new(&i, &c, fr);
         ot.set("f", &ft);
 
         let o = ot.new_instance(&c);

--- a/src/template.rs
+++ b/src/template.rs
@@ -49,9 +49,9 @@ impl<'a> Signature<'a> {
 /// Any modification of a FunctionTemplate after first instantiation will trigger a crash.
 /// A FunctionTemplate can have properties, these properties are added to the function object when it is created.
 impl<'a> FunctionTemplate<'a> {
-    pub fn new<'b>(isolate: &'a isolate::Isolate,
+    pub fn new(isolate: &'a isolate::Isolate,
                context: &context::Context<'a>,
-               callback: &'b Fn(&'a value::FunctionCallbackInfo) -> value::Value<'a>)
+               callback: &'a Fn(&'a value::FunctionCallbackInfo) -> value::Value<'a>)
                 -> FunctionTemplate<'a> {
         let raw = unsafe {
             let callback = Box::into_raw(Box::new(callback));

--- a/src/template.rs
+++ b/src/template.rs
@@ -73,7 +73,7 @@ impl<'a> FunctionTemplate<'a> {
         FunctionTemplate(isolate, raw)
     }
 
-    pub fn get_function(&self, context: &context::Context) -> value::Function<'a> {
+    pub fn get_function(self, context: &context::Context) -> value::Function<'a> {
         unsafe {
             let raw = util::invoke(self.0,
                                    |c| v8::FunctionTemplate_GetFunction(c, self.1, context.as_raw()))

--- a/src/template.rs
+++ b/src/template.rs
@@ -2,9 +2,13 @@ use v8_sys as v8;
 use isolate;
 use util;
 use value;
+use value::Data;
 use context;
 use std::os;
 use std::ptr;
+use std::mem;
+use std::ops;
+use std::ffi;
 
 #[derive(Debug)]
 pub struct Template<'a>(&'a isolate::Isolate, v8::TemplateRef);
@@ -14,6 +18,71 @@ pub struct FunctionTemplate<'a>(&'a isolate::Isolate, v8::FunctionTemplateRef);
 
 #[derive(Debug)]
 pub struct ObjectTemplate<'a>(&'a isolate::Isolate, v8::ObjectTemplateRef);
+
+#[derive(Debug)]
+pub struct Signature<'a>(&'a isolate::Isolate, v8::SignatureRef);
+
+/// A Signature specifies which receiver is valid for a function.
+impl<'a> Signature<'a> {
+    pub fn new(isolate: &'a isolate::Isolate) -> Signature<'a> {
+        let raw = unsafe {
+            util::invoke(isolate,
+                         |c| v8::Signature_New(c, isolate.as_raw(), ptr::null_mut()))
+                .unwrap()
+        };
+        Signature(isolate, raw)
+    }
+
+    pub fn new_with_receiver(isolate: &'a isolate::Isolate, receiver: &FunctionTemplate) -> Signature<'a> {
+        let raw = unsafe {
+            util::invoke(isolate,
+                         |c| v8::Signature_New(c, isolate.as_raw(), receiver.1))
+                .unwrap()
+        };
+        Signature(isolate, raw)
+    }
+}
+
+/// A FunctionTemplate is used to create functions at runtime. 
+/// There can only be one function created from a FunctionTemplate in a context.
+///
+/// Any modification of a FunctionTemplate after first instantiation will trigger a crash.
+/// A FunctionTemplate can have properties, these properties are added to the function object when it is created.
+impl<'a> FunctionTemplate<'a> {
+    pub fn new<'b>(isolate: &'a isolate::Isolate,
+               context: &context::Context<'a>,
+               callback: &'b Fn(&'a value::FunctionCallbackInfo) -> value::Value<'a>)
+                -> FunctionTemplate<'a> {
+        let raw = unsafe {
+            let callback = Box::into_raw(Box::new(callback));
+            let template = ObjectTemplate::new(isolate);
+            template.set_internal_field_count(1);
+            let closure = template.new_instance(context);
+            closure.set_aligned_pointer_in_internal_field(0, callback);
+
+            util::invoke(isolate,
+                         |c| v8::FunctionTemplate_New(c,
+                                                      context.as_raw(),
+                                                      Some(util::callback),
+                                                      (&closure as &value::Value).as_raw(),
+                                                      ptr::null_mut(),
+                                                      0,
+                                                      v8::ConstructorBehavior::ConstructorBehavior_kAllow))
+                .unwrap()
+        };
+        FunctionTemplate(isolate, raw)
+    }
+
+    pub fn get_function(&self, context: &context::Context) -> value::Function<'a> {
+        unsafe {
+            let raw = util::invoke(self.0,
+                                   |c| v8::FunctionTemplate_GetFunction(c, self.1, context.as_raw()))
+                .unwrap();
+            value::Function::from_raw(self.0, raw)
+        }
+    }
+}
+
 
 /// An ObjectTemplate is used to create objects at runtime.
 ///
@@ -34,6 +103,17 @@ impl<'a> ObjectTemplate<'a> {
                     v8::ObjectTemplate_SetInternalFieldCount(c, self.1, value as os::raw::c_int)
                 })
                 .unwrap()
+        };
+    }
+
+    pub fn set(&self, name: &str, value: &value::Data) {
+        let cname = ffi::CString::new(name).unwrap();
+        let template: &Template = self;
+        unsafe {
+            util::invoke(self.0, |c| {
+                v8::Template_Set_Raw(c, template.1, self.0.as_raw(), cname.as_ptr(), value.as_raw())
+            })
+            .unwrap()  
         };
     }
 
@@ -59,6 +139,12 @@ impl<'a> ObjectTemplate<'a> {
     }
 }
 
+inherit!(Template, Data);
+inherit!(ObjectTemplate, Template);
+inherit!(FunctionTemplate, Template);
+inherit!(Signature, Data);
+
 drop!(Template, v8::Template_DestroyRef);
 drop!(FunctionTemplate, v8::FunctionTemplate_DestroyRef);
 drop!(ObjectTemplate, v8::ObjectTemplate_DestroyRef);
+drop!(Signature, v8::Signature_DestroyRef);

--- a/src/value.rs
+++ b/src/value.rs
@@ -1527,10 +1527,10 @@ impl<'a> Set<'a> {
 
 impl<'a> Function<'a> {
     /// Create a function in the current execution context for a given callback.
-    pub fn new(isolate: &'a isolate::Isolate,
+    pub fn new<'b>(isolate: &'a isolate::Isolate,
                context: &context::Context<'a>,
                length: usize,
-               callback: &'a Fn(&'a FunctionCallbackInfo) -> Value<'a>)
+               callback: &'b Fn(&'a FunctionCallbackInfo) -> Value<'a>)
                -> Function<'a> {
         unsafe {
             let callback = Box::into_raw(Box::new(callback));

--- a/src/value.rs
+++ b/src/value.rs
@@ -1527,10 +1527,10 @@ impl<'a> Set<'a> {
 
 impl<'a> Function<'a> {
     /// Create a function in the current execution context for a given callback.
-    pub fn new<'b>(isolate: &'a isolate::Isolate,
+    pub fn new(isolate: &'a isolate::Isolate,
                context: &context::Context<'a>,
                length: usize,
-               callback: &'b Fn(&'a FunctionCallbackInfo) -> Value<'a>)
+               callback: &'a Fn(&'a FunctionCallbackInfo) -> Value<'a>)
                -> Function<'a> {
         unsafe {
             let callback = Box::into_raw(Box::new(callback));

--- a/v8-sys/Cargo.toml
+++ b/v8-sys/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.10.0"
 bindgen = "0.19.0"
 clang = "0.12.0"
 gcc = "0.3.35"
-v8-api = "0.4.0"
+v8-api = { version = "0.4.0", path = "../v8-api" }
 
 [dev-dependencies]
 lazy_static = "0.2.1"

--- a/v8-sys/src/v8-glue.h
+++ b/v8-sys/src/v8-glue.h
@@ -342,6 +342,7 @@ ArrayBuffer_AllocatorPtr v8_ArrayBuffer_Allocator_Create(v8_AllocatorFunctions a
 void v8_ArrayBuffer_Allocator_Destroy(ArrayBuffer_AllocatorPtr allocator);
 
 IsolatePtr v8_Isolate_New(ArrayBuffer_AllocatorPtr allocator);
+ContextRef v8_Isolate_GetCurrentContext(IsolatePtr self);
 void v8_Isolate_SetCaptureStackTraceForUncaughtExceptions_Overview(IsolatePtr self, bool capture, int frame_limit);
 void v8_Isolate_SetCaptureStackTraceForUncaughtExceptions_Detailed(IsolatePtr self, bool capture, int frame_limit);
 void v8_Isolate_Dispose(IsolatePtr isolate);
@@ -375,6 +376,8 @@ ObjectRef v8_Function_NewInstance(RustContext c, FunctionRef self, ContextRef co
 ValueRef v8_Function_Call(RustContext c, FunctionRef self, ContextRef context, ValueRef recv, int argc, ValueRef argv[]);
 
 void v8_Template_SetNativeDataProperty(RustContext c, TemplateRef self, StringRef name, AccessorGetterCallback getter, AccessorSetterCallback setter, ValueRef data, PropertyAttribute attribute, AccessorSignatureRef signature, AccessControl settings);
+
+FunctionTemplateRef v8_FunctionTemplate_New(RustContext c, ContextRef context, FunctionCallback wrapped_callback, ValueRef data, SignatureRef signature, int length, ConstructorBehavior behavior);
 
 void v8_ObjectTemplate_SetAccessor(RustContext c, ObjectTemplateRef self, StringRef name, AccessorGetterCallback getter, AccessorSetterCallback setter, ValueRef data, AccessControl settings, PropertyAttribute attribute, AccessorSignatureRef signature);
 void v8_ObjectTemplate_SetAccessor_Name(RustContext c, ObjectTemplateRef self, StringRef name, AccessorNameGetterCallback getter, AccessorNameSetterCallback setter, ValueRef data, AccessControl settings, PropertyAttribute attribute, AccessorSignatureRef signature);


### PR DESCRIPTION
Example:

```
extern crate v8;

use v8::value;

fn log<'a>(args: &'a v8::value::FunctionCallbackInfo) -> v8::Value<'a> {
    if args.length < 1 { return v8::value::Value::from(v8::value::undefined(args.isolate)); }
    let context = args.isolate.current_context();

    let ref value = args.args[0];
    println!("{}", value.to_string(&context).to_string());

    v8::value::Value::from(v8::value::undefined(args.isolate))
}

fn main() {
    let isolate = v8::Isolate::new();
    let context = v8::Context::new(&isolate);

    let test_ot = v8::template::ObjectTemplate::new(&isolate);
    test_ot.set("test", &value::Integer::new(&isolate, 5));
    test_ot.set("log", &v8::template::FunctionTemplate::new(&isolate, &context, &log));

    let test = test_ot.new_instance(&context);
    let global = context.global();
    global.set(&context, &value::String::from_str(&isolate, "test"), &test);

    let source = value::String::from_str(&isolate, "test.log('foobar'); 'Hello, ' + test.test;");

    let script = v8::Script::compile(&isolate, &context, &source).unwrap();
    let result = script.run(&context).unwrap();
    let result_str = result.to_string(&context);

    println!("Script result = {}", result_str.to_string());
}
```