### PR TITLE
Match the callback boxing of Function::new in TemplateFunction::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,8 +602,7 @@ mod tests {
     fn run_defined_static_function() {
         let i = Isolate::new();
         let c = Context::new(&i);
-        let fr = &test_function;
-        let f = value::Function::new(&i, &c, 2, fr);
+        let f = value::Function::new(&i, &c, 2, test_function);
 
         let k = value::String::from_str(&i, "f");
         c.global().set(&c, &k, &f);
@@ -621,8 +620,7 @@ mod tests {
     fn run_defined_function_template_instance() {
         let i = Isolate::new();
         let c = Context::new(&i);
-        let fr = &test_function;
-        let ft = template::FunctionTemplate::new(&i, &c, fr);
+        let ft = template::FunctionTemplate::new(&i, &c, test_function);
         let f = ft.get_function(&c);
 
         let k = value::String::from_str(&i, "f");
@@ -662,8 +660,7 @@ mod tests {
         let i = Isolate::new();
         let c = Context::new(&i);
         let ot = template::ObjectTemplate::new(&i);
-        let fr = &test_function;
-        let ft = template::FunctionTemplate::new(&i, &c, fr);
+        let ft = template::FunctionTemplate::new(&i, &c, test_function);
         ot.set("f", &ft);
 
         let o = ot.new_instance(&c);

--- a/src/template.rs
+++ b/src/template.rs
@@ -54,11 +54,11 @@ impl FunctionTemplate {
                   callback: F) -> FunctionTemplate
         where F: Fn(value::FunctionCallbackInfo) -> value::Value {
         let raw = unsafe {
-            let callback = Box::into_raw(Box::new(callback));
+            let callback_ptr: *mut Box<F> = Box::into_raw(Box::new(Box::new(callback)));
             let template = ObjectTemplate::new(isolate);
             template.set_internal_field_count(1);
             let closure = template.new_instance(context);
-            closure.set_aligned_pointer_in_internal_field(0, callback);
+            closure.set_aligned_pointer_in_internal_field(0, callback_ptr);
 
             util::invoke(isolate,
                          |c| v8::FunctionTemplate_New(c,


### PR DESCRIPTION
Change function tests to pass fn items instead of references.

While working on this change it occurred to me that it isn't safe for the callbacks to be closures. Once these callback functions are exposed to JS they can be referenced and held by JS code indefinitely so the function and any captured environment must live as long as the isolate.

A potential strategy for handling this would be to only allow 'static functions or closures that pass ownership of their environment to V8 through the internal object. Ownership could also be shared through Rc<T>. This should still be convenient to work with in rust while ensuring the callbacks are safe for the duration of the isolate.

The move ownership to V8 or Rc<T> strategy would also be useful when storing rust values in a value::Object's internal fields.
