### PR TITLE
Safe interface for storing rust values within JS objects

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -7,6 +7,7 @@ use value::Data;
 use context;
 use std::os;
 use std::ptr;
+use std::marker::PhantomData;
 use std::mem;
 use std::ops;
 use std::ffi;
@@ -21,13 +22,13 @@ pub struct Template(isolate::Isolate, v8::TemplateRef);
 /// of a FunctionTemplate after first instantiation will trigger a crash.  A FunctionTemplate can
 /// have properties, these properties are added to the function object when it is created.
 #[derive(Debug)]
-pub struct FunctionTemplate(isolate::Isolate, v8::FunctionTemplateRef);
+pub struct FunctionTemplate<T = ()>(isolate::Isolate, v8::FunctionTemplateRef, PhantomData<T>);
 
 /// An ObjectTemplate is used to create objects at runtime.
 ///
 /// Properties added to an ObjectTemplate are added to each object created from the ObjectTemplate.
 #[derive(Debug)]
-pub struct ObjectTemplate(isolate::Isolate, v8::ObjectTemplateRef);
+pub struct ObjectTemplate<T = ()>(isolate::Isolate, v8::ObjectTemplateRef, PhantomData<T>);
 
 /// A Signature specifies which receiver is valid for a function.
 #[derive(Debug)]
@@ -55,15 +56,15 @@ impl Signature {
     }
 }
 
-impl FunctionTemplate {
+impl<T> FunctionTemplate<T> {
     /// Creates a function template.
     pub fn new(isolate: &isolate::Isolate,
                context: &context::Context,
-               callback: Box<Fn(value::FunctionCallbackInfo) -> value::Value + 'static>)
-               -> FunctionTemplate {
+               callback: Box<Fn(value::FunctionCallbackInfo<T>) -> value::Value + 'static>)
+               -> FunctionTemplate<T> {
         let raw = unsafe {
             let callback_ptr = Box::into_raw(Box::new(callback));
-            let callback_ext = value::External::new::<Box<Fn(value::FunctionCallbackInfo) -> value::Value + 'static>>(&isolate, callback_ptr);
+            let callback_ext = value::External::new::<Box<Fn(value::FunctionCallbackInfo<T>) -> value::Value + 'static>>(&isolate, callback_ptr);
 
             let template = ObjectTemplate::new(isolate);
             template.set_internal_field_count(1);
@@ -74,7 +75,7 @@ impl FunctionTemplate {
             util::invoke(isolate, |c| {
                     v8::FunctionTemplate_New(c,
                                              context.as_raw(),
-                                             Some(util::callback),
+                                             Some(util::callback::<T>),
                                              (&closure as &value::Value).as_raw(),
                                              ptr::null_mut(),
                                              0,
@@ -82,7 +83,7 @@ impl FunctionTemplate {
                 })
                 .unwrap()
         };
-        FunctionTemplate(isolate.clone(), raw)
+        FunctionTemplate::<T>(isolate.clone(), raw, PhantomData)
     }
 
     /// Returns the unique function instance in the current execution context.
@@ -95,27 +96,42 @@ impl FunctionTemplate {
             value::Function::from_raw(&self.0, raw)
         }
     }
+
+    /// Returns the underlying raw pointer behind this function template.
+    pub fn as_raw(&self) -> v8::FunctionTemplateRef {
+        self.1
+    }
 }
 
 impl ObjectTemplate {
     /// Creates an ObjectTemplate.
     pub fn new(isolate: &isolate::Isolate) -> ObjectTemplate {
+        ObjectTemplate::<()>::with_internal(isolate)
+    }
+
+    /// Creates an ObjectTemplate<T> where T is the type of the internal rust object.
+    pub fn with_internal<T>(isolate: &isolate::Isolate) -> ObjectTemplate<T> {
         let raw = unsafe {
             util::invoke(isolate,
                          |c| v8::ObjectTemplate_New(c, isolate.as_raw(), ptr::null_mut()))
                 .unwrap()
         };
-        ObjectTemplate(isolate.clone(), raw)
+        ObjectTemplate(isolate.clone(), raw, PhantomData)
+    }
+}
+
+impl<T> ObjectTemplate<T> {
+    /// Returns the number of internal fields for objects generated from this template.
+    pub fn internal_field_count(&self) -> i32 {
+        unsafe { util::invoke(&self.0, |c| { v8::ObjectTemplate_InternalFieldCount(c, self.1)}).unwrap() }
     }
 
     /// Sets the number of internal fields for objects generated from this template.
-    pub fn set_internal_field_count(&self, value: usize) {
-        unsafe {
-            util::invoke(&self.0, |c| {
-                    v8::ObjectTemplate_SetInternalFieldCount(c, self.1, value as os::raw::c_int)
-                })
-                .unwrap()
-        };
+    pub unsafe fn set_internal_field_count(&self, value: usize) {
+        util::invoke(&self.0, |c| {
+                v8::ObjectTemplate_SetInternalFieldCount(c, self.1, value as os::raw::c_int)
+            })
+            .unwrap();
     }
 
     pub fn set(&self, name: &str, value: &value::Data) {
@@ -133,6 +149,22 @@ impl ObjectTemplate {
         };
     }
 
+    /// Sets a function template as `name` on instances of this template ensuring that the callback type of the FunctionTemplate matches the object instance internal type.
+    pub fn set_callback(&self, name: &str, value: &FunctionTemplate<T>) {
+        let cname = ffi::CString::new(name).unwrap();
+        let template: &Template = self;
+        unsafe {
+            util::invoke(&self.0, |c| {
+                    v8::Template_Set_Raw(c,
+                                         template.1,
+                                         self.0.as_raw(),
+                                         cname.as_ptr(),
+                                         value.as_raw() as v8::DataRef)
+                })
+                .unwrap()
+        }; 
+    }
+
     /// Creates a new object instance based off of this template.
     pub fn new_instance(&self, context: &context::Context) -> value::Object {
         unsafe {
@@ -143,11 +175,27 @@ impl ObjectTemplate {
         }
     }
 
+    // Creates a new object instance based off this template with an internal rust object accessible from callbacks.
+    pub fn new_instance_with_internal(&self, context: &context::Context, internal: T) -> value::Object {
+        let wrapped_ptr: *mut Box<T> = Box::into_raw(Box::new(Box::new(internal)));
+        if self.internal_field_count() < 1 { 
+            unsafe { self.set_internal_field_count(1) };
+        }
+
+        let object = self.new_instance(context);
+
+        unsafe {
+            let external = value::External::new(&self.0, wrapped_ptr);
+            object.set_internal_field(0, &external);
+        }
+        object
+    }
+
     /// Creates an object template from a set of raw pointers.
     pub unsafe fn from_raw(isolate: &isolate::Isolate,
                            raw: v8::ObjectTemplateRef)
                            -> ObjectTemplate {
-        ObjectTemplate(isolate.clone(), raw)
+        ObjectTemplate(isolate.clone(), raw, PhantomData)
     }
 
     /// Returns the underlying raw pointer behind this object template.
@@ -156,16 +204,54 @@ impl ObjectTemplate {
     }
 }
 
+impl<T> Clone for FunctionTemplate<T> {
+    fn clone(&self) -> FunctionTemplate<T> {
+        let raw = unsafe { util::invoke(&self.0, |c| v8::FunctionTemplate_CloneRef(c, self.1)).unwrap() };
+        FunctionTemplate(self.0.clone(), raw, PhantomData)
+    }
+}
+
+impl<T> Drop for FunctionTemplate<T> {
+    fn drop(&mut self) {
+        unsafe {
+            v8::FunctionTemplate_DestroyRef(self.1)
+        }
+    }
+}
+
+impl<T> Clone for ObjectTemplate<T> {
+    fn clone(&self) -> ObjectTemplate<T> {
+        let raw = unsafe { util::invoke(&self.0, |c| v8::ObjectTemplate_CloneRef(c, self.1)).unwrap() };
+        ObjectTemplate(self.0.clone(), raw, PhantomData)
+    }
+}
+
+impl<T> Drop for ObjectTemplate<T> {
+    fn drop(&mut self) {
+        unsafe {
+            v8::ObjectTemplate_DestroyRef(self.1)
+        }
+    }
+}
+
+impl<T> From<ObjectTemplate<T>> for Template {
+    fn from(child: ObjectTemplate<T>) -> Template {
+        unsafe { mem::transmute(child) }
+    }
+}
+
+
+impl<T> ops::Deref for ObjectTemplate<T> {
+    type Target = Template;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { mem::transmute(self) }
+    }
+}
+
 inherit!(Template, Data);
-inherit!(ObjectTemplate, Template);
 inherit!(FunctionTemplate, Template);
 inherit!(Signature, Data);
 
 reference!(Template, v8::Template_CloneRef, v8::Template_DestroyRef);
-reference!(FunctionTemplate,
-           v8::FunctionTemplate_CloneRef,
-           v8::FunctionTemplate_DestroyRef);
-reference!(ObjectTemplate,
-           v8::ObjectTemplate_CloneRef,
-           v8::ObjectTemplate_DestroyRef);
 reference!(Signature, v8::Signature_CloneRef, v8::Signature_DestroyRef);

--- a/src/template.rs
+++ b/src/template.rs
@@ -175,7 +175,7 @@ impl<T> ObjectTemplate<T> {
         }
     }
 
-    // Creates a new object instance based off this template with an internal rust object accessible from callbacks.
+    /// Creates a new object instance based off of this template with an internal rust object accessible from callbacks.
     pub fn new_instance_with_internal(&self, context: &context::Context, internal: T) -> value::Object {
         let wrapped_ptr: *mut Box<T> = Box::into_raw(Box::new(Box::new(internal)));
         if self.internal_field_count() < 1 { 

--- a/src/value.rs
+++ b/src/value.rs
@@ -215,12 +215,13 @@ pub struct PropertyCallbackInfo {
     pub holder: Object,
 }
 
-pub struct FunctionCallbackInfo {
+pub struct FunctionCallbackInfo<'a, T: 'a = ()> {
     pub isolate: isolate::Isolate,
     pub length: isize,
     pub args: Vec<Value>,
     pub this: Object,
     pub holder: Object,
+    pub internal: Option<&'a mut T>,
     pub new_target: Value,
     pub is_construct_call: bool,
 }
@@ -1605,7 +1606,7 @@ impl Function {
             let raw = util::invoke(&isolate, |c| {
                     v8::Function_New(c,
                                      context.as_raw(),
-                                     Some(util::callback),
+                                     Some(util::callback::<()>),
                                      (&closure as &Value).as_raw(),
                                      length as os::raw::c_int,
                                      v8::ConstructorBehavior::ConstructorBehavior_kAllow)


### PR DESCRIPTION
### Summary

I've put together a safe\* interface for holding rust objects within JS objects. I'm submitting this as a pull request to start a discussion over the design.
### Design

ObjectTemplate, FunctionTemplate and FunctionCallbackInfo now accept a generic type T representing the type of the wrapped rust value. The PhantomData marker is used to carry the type information even though the pointer is stored within V8.

The default behavior (compatible with existing code) is to make this generic type the unit type. Objects that embed a rust object must be created through an ObjectTemplate<T> to ensure that that set_internal_field_count is called appropriately. Callbacks that use this type must be a FunctionTemplate<T> set on the ObjectTemplate<T> with the set_callback method. ObjectTemplate::set_internal_field_count is now marked unsafe because changing the value to 0 while using wrapped rust values would lead to undefined behavior.

The rust object is moved into the Object when creating an instance and can be considered owned by the V8 GC. Objects can be shared mutably with V8 by using an Rc<RefCell<T>>. A &mut reference is passed to the callback within the FunctionCallbackInfo struct.
### Issues
1. If the type of callback doesn't match the ObjectTemplate it fails to compile but with a fairly dense type error and references a line of code that doesn't clearly show the problem.

`error[E0281]: type mismatch: the type `fn(v8::value::FunctionCallbackInfo<'_, std::rc::Rc<std::cell::RefCell<Foo>>>) -> v8::Value {test}` implements the trait `for<'r> std::ops::Fn<(v8::value::FunctionCallbackInfo<'r, std::rc::Rc<std::cell::RefCell<Foo>>>,)>`, but the trait `for<'r> std::ops::Fn<(v8::value::FunctionCallbackInfo<'r>,)>` is required (expected (), found struct `std::rc::Rc`)`
1. A finalizer callback needs to drop the rust object when the JS object is garbage collected.
2. ObjectTemplate might benefit from having two distinct types to represent the one with and without an internal rust object to prevent invalid combinations of method calls at compile time. It is safe, but may result in args.internal being None unexpectedly.
3. The safety of this interface depends on certain combinations of ObjectTemplates and FunctionTemplates failing to compile. It would benefit from testing with compiletest-rs to ensure that these combinations result in a compile-time error.
4. The object can only have one rust value instead of N.
- Should be safe
