### PR TITLE
Use Clang to autodetect include paths in the build.rs script.

### DIFF
--- a/v8-sys/Cargo.toml
+++ b/v8-sys/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.14.1"
 [build-dependencies]
 bindgen = "0.19.0"
 clang = "0.13.0"
+clang-sys = "0.13.0"
 gcc = "0.3.38"
 pkg-config = "0.3.8"
 

--- a/v8-sys/build.rs
+++ b/v8-sys/build.rs
@@ -1,6 +1,7 @@
 extern crate v8_api;
 extern crate bindgen;
 extern crate clang;
+extern crate clang_sys;
 extern crate gcc;
 extern crate pkg_config;
 
@@ -54,14 +55,14 @@ fn main() {
 }
 
 fn read_api() -> v8_api::Api {
-    let mut extra_includes = if let Some(dir_str) = env::var_os("V8_SOURCE") {
-        vec![path::PathBuf::from(dir_str).join("include")]
-    } else {
-        vec![]
-    };
+    let mut extra_includes = vec![];
 
-    extra_includes.push("/usr/include".into());
-    extra_includes.push("/usr/local/include".into());
+    if let Some(dir_str) = env::var_os("V8_SOURCE") {
+        extra_includes.push(path::PathBuf::from(dir_str).join("include"));
+    }
+
+    let clang = clang_sys::support::Clang::find(None).expect("No clang found, is it installed?");
+    extra_includes.extend_from_slice(&clang.c_search_paths);
 
     let trampoline_path = path::Path::new("src/v8-trampoline.h");
 


### PR DESCRIPTION
This implements the solution proposed by @SrTobi in #14 in order to improve the detection of some header files. 
It uses Clang through the `clang-sys` crate, and fixes the compilation of the `v8-sys` crate on some Linux systems (tested on Arch Linux x86_64).