### PR TITLE
Add v8 5.7 support.

### DIFF
--- a/v8-sys/src/lib.rs
+++ b/v8-sys/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;

--- a/v8-sys/src/v8-glue.cc
+++ b/v8-sys/src/v8-glue.cc
@@ -952,7 +952,9 @@ ScriptRef v8_Script_Compile_Origin(
         wrap(c.isolate, resource_column_offset),
         wrap(c.isolate, resource_is_shared_cross_origin),
         wrap(c.isolate, script_id),
-        wrap(c.isolate, resource_is_embedder_debug_script),
+        #if V8_MAJOR_VERSION < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 7)
+            wrap(c.isolate, resource_is_embedder_debug_script),
+        #endif
         wrap(c.isolate, source_map_url),
         wrap(c.isolate, resource_is_opaque));
 


### PR DESCRIPTION
This commit adds support for v8 5.7.

The only breaking change in the v8 API is the removal of the `resource_is_embedder_debug_script` argument of the `ScriptOrigin` constructor. It is now ignored when compiled for v8 5.7 and newer.

With #15 and #16, this patch should fix the compilation on ArchLinux x86_64 (and on any system that brings recent versions of Clang and v8), and therefore should probably fix #14 as well.


As a bonus, this commit also fixes the generation of lots of warnings related to incorrect casing in the `ffi` generated module.
